### PR TITLE
Update bbox_utils.py

### DIFF
--- a/layers/bbox_utils.py
+++ b/layers/bbox_utils.py
@@ -325,10 +325,10 @@ def nms(boxes, scores, overlap=0.5, top_k=200):
             break
         idx = idx[:-1]  # remove kept element from view
         # load bboxes of next highest vals
-        torch.index_select(x1, 0, idx, out=xx1)
-        torch.index_select(y1, 0, idx, out=yy1)
-        torch.index_select(x2, 0, idx, out=xx2)
-        torch.index_select(y2, 0, idx, out=yy2)
+        xx1 = torch.index_select(x1, 0, idx)
+        yy1 = torch.index_select(y1, 0, idx)
+        xx2 = torch.index_select(x2, 0, idx)
+        yy2 = torch.index_select(y2, 0, idx)
         # store element-wise max with next highest score
         xx1 = torch.clamp(xx1, min=x1[i])
         yy1 = torch.clamp(yy1, min=y1[i])


### PR DESCRIPTION
Fixes a PyTorch 1.12 Warning

In PyTorch 1.12 the implicit resizing generates a warning.
Removing the output and explicitly sets the new data removes the warnings.

This fixes #2 .